### PR TITLE
Add missinig dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,11 +32,8 @@ scripts =
 	bin/never
 install_requires = 
 	gitpython
-
-[options.packages.find]
-where = src
-
-thon
+    python-dotenv
+    requests
 
 [options.packages.find]
 where = src


### PR DESCRIPTION
`python-dotenv` and `requests` were missing in `setup.cfg` as dependencies.